### PR TITLE
Direct users to install @openai/codex instead of @openai/codex@native

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Palette.
 1. **Install the Codex CLI** (the plug-in talks to the CLI, it is **not** bundled).
 
    ```bash
-   npm i -g @openai/codex@native   # or any recent version that supports `proto`
+   npm i -g @openai/codex   # or any recent version that supports `proto`
    ```
 
    By default the plug-in looks for the binary at:


### PR DESCRIPTION
We stopped updating the `@openai/codex@native` flavor of the npm module a little while and now `@openai/codex` is a small Node.js wrapper around the native CLI.

Personally, I prefer installing via `brew` because:

- it eliminates the Node.js wrapper
- it is a smaller download (the `npm` module has binaries for all architectures)
- it installs shell completions