### PR TITLE
Do not call `destroy_output_panel`

### DIFF
--- a/plugin/commands.py
+++ b/plugin/commands.py
@@ -677,9 +677,7 @@ class CodexSubmitInputPanelCommand(sublime_plugin.WindowCommand):
             sublime.status_message('prompt is empty')
             return
 
-        # Close and destroy the input panel so it does not linger in the panel list.
         self.window.run_command('hide_panel')
-        self.window.destroy_output_panel(self.INPUT_PANEL_NAME)
 
         bridge = get_bridge(self.window)
         project_data = self.window.project_data() or {}


### PR DESCRIPTION
`destroy_output_panel` is not recommended as Sublime Text will forget the panel size (height) if you do so.  Keep it lingering for now and maybe switch to a full view at some point.