### PR TITLE
Friendly stream decoding

### DIFF
--- a/plugin/codex_bridge.py
+++ b/plugin/codex_bridge.py
@@ -189,6 +189,8 @@ class _CodexBridge:
             'stdout': subprocess.PIPE,
             'stderr': subprocess.STDOUT,
             'text': True,
+            'encoding': 'utf-8',
+            'errors': 'replace',
             'bufsize': 1,
             'env': env,
             'cwd': self._cwd,


### PR DESCRIPTION
(a) We don't want to crash on decoding errors.
(b) We explicitly set "utf-8".  This is needed on Windows but likely doesn't hurt on the other systems.