### PR TITLE
Handle apply patch approvals in Sublime UI

### DIFF
--- a/plugin/commands.py
+++ b/plugin/commands.py
@@ -110,6 +110,32 @@ def _get_fold_section_names(window: sublime.Window) -> set[str]:  # type: ignore
     return names
 
 
+def _format_patch_changes(changes: dict) -> str:
+    """Return a Markdown representation of patch *changes*."""
+
+    body = ''
+
+    if not isinstance(changes, dict):
+        return body
+
+    for file_path, change_info in changes.items():
+        if not isinstance(change_info, dict):
+            continue
+
+        file_label = str(file_path)
+        op_type = next(iter(change_info.keys()), '')
+        op_suffix = f' ({op_type})' if op_type else ''
+        body += f'**{file_label}**{op_suffix}\n'
+
+        diff_payload = change_info.get(op_type, {}) if isinstance(change_info, dict) else {}
+        if isinstance(diff_payload, dict):
+            unified_diff = diff_payload.get('unified_diff')
+            if unified_diff:
+                body += f'```diff\n{unified_diff}\n```\n\n'
+
+    return body
+
+
 def _display_assistant_response(window: sublime.Window, prompt: str, event: dict, session_id: str) -> None:  # type: ignore[name-defined]
     """Append the Codex *event* to output panel using markdown formatting."""
 
@@ -395,6 +421,50 @@ def _display_assistant_response(window: sublime.Window, prompt: str, event: dict
     # apply_patch wrapper events ---------------------------------------
     # ------------------------------------------------------------------
 
+    elif msg_type == 'apply_patch_approval_request':
+        header = '### apply_patch_approval\n\n'
+        header_title_for_fold = 'apply_patch_approval'
+
+        reason = msg.get('reason')
+        if reason:
+            body += f'*Reason*: {str(reason)}\n\n'
+
+        grant_root = msg.get('grant_root')
+        if grant_root:
+            body += f'`grant_root`: `{str(grant_root)}`\n\n'
+
+        body += _format_patch_changes(msg.get('changes', {}))
+
+        quick_panel_items = [
+            ['Yes', 'Apply these changes'],
+            ['No', 'Reject the patch but keep the session running'],
+            ['Abort Execution', 'Stop session completely'],
+        ]
+
+        def _on_done(index: int, *, _window=window, _event=event):  # noqa: D401 – callback
+            choice_map = {
+                0: 'approved',
+                1: 'denied',
+                2: 'abort',
+                -1: 'denied',
+            }
+
+            decision = choice_map.get(index, 'denied')
+            logger.debug('call id for approval: %s', _event.get('id', 'wrong_id'))
+            bridge = get_bridge(_window)
+            bridge.send(
+                {
+                    'id': session_id,
+                    'op': {
+                        'id': _event.get('id'),
+                        'type': 'patch_approval',
+                        'decision': decision,
+                    },
+                },
+            )
+
+        window.show_quick_panel(quick_panel_items, _on_done)
+
     elif msg_type == 'patch_apply_begin':
         header = '### Applying patch\n\n'
         header_title_for_fold = 'Applying patch'
@@ -402,19 +472,7 @@ def _display_assistant_response(window: sublime.Window, prompt: str, event: dict
         auto_approved = msg.get('auto_approved', False)
         body = f'`auto_approved`: {auto_approved}\n\n'
 
-        changes = msg.get('changes', {})
-        if isinstance(changes, dict):
-            for file_path, change_info in changes.items():
-                # Determine operation type.
-                op_type = next(iter(change_info.keys()), '') if isinstance(change_info, dict) else ''
-                body += f'**{file_path}** ({op_type})\n'
-
-                diff_payload = change_info.get(op_type, {}) if isinstance(change_info, dict) else {}
-                unified_diff = diff_payload.get('unified_diff') if isinstance(diff_payload, dict) else None
-
-                if unified_diff:
-                    # Wrap diff in a code block so it renders nicely in Markdown.
-                    body += f'```diff\n{unified_diff}\n```\n\n'
+        body += _format_patch_changes(msg.get('changes', {}))
 
     elif msg_type == 'patch_apply_end':
         header = ''


### PR DESCRIPTION
## Summary
- handle apply_patch_approval_request events by displaying the pending changes and prompting for a decision
- extract a shared helper to format patch change summaries for approval and apply events

## Testing
- python3 -m compileall plugin

------
https://chatgpt.com/codex/tasks/task_b_68ca8a4bc52483308b3210db5d765770