### PR TITLE
Fix `codex_path` handling

### DIFF
--- a/Codex.sublime-settings
+++ b/Codex.sublime-settings
@@ -1,6 +1,13 @@
 {
-    // Path to the Codex CLI. You can also specify a list for complex launchers,
-    // e.g. ["wsl", "-e", "codex"]. A plain string is split similar to a shell.
+    // The Codex executable.  Can be a string or a list of strings.
+    // E.g. "codex", "sh --login-i -c codex", or "wsl -e codex" as long as the
+    // executable, the first arg, can be found on the PATH.
+    // In other words `which` or `where` on Windows must resolve it.
+    // Note that the plain string is split similar to a shell.  Esp. on Windows
+    // paths needs quotes and "\" slashes needs extra-care.
+    // E.g. "\"C:\\Program Files\\codex.exe\"".  You can avoid that by using
+    // the list format.
+    // Example for the list format: ["wsl", "-e", "codex"].
     "codex_path": "codex",
 
     // Your provider API token used by the CLI (exported as OPENAI_API_KEY by default).

--- a/plugin/codex_bridge.py
+++ b/plugin/codex_bridge.py
@@ -221,21 +221,22 @@ class _CodexBridge:
 
         cmd: list[str]
         if isinstance(raw_cmd, str):
-            if not os.path.isabs(raw_cmd):
-                cmd = [shutil.which(raw_cmd)]
-                if cmd == [None]:
-                    raise RuntimeError(
-                        f"which('{raw_cmd}') did not yield anything. \n"
-                        f"Make sure codex is installed already and available "
-                        f"on the command line. "
-                        f"Maybe point codex_path in your settings to its location."
-                    )
-            else:
-                cmd = shlex.split(raw_cmd)
+            cmd = shlex.split(raw_cmd)
         elif isinstance(raw_cmd, (list, tuple)):
             cmd = list(raw_cmd)
         else:  # pragma: no cover – invalid type guarded at runtime
             raise TypeError('codex_path must be str or list[str]')
+
+        executable = cmd[0]
+        if not os.path.isabs(executable):
+            cmd[0] = shutil.which(executable)
+            if cmd[0] is None:
+                raise RuntimeError(
+                    f"which({executable}) did not yield anything. \n"
+                    "Make sure it is installed and available "
+                    "on the command line. "
+                    "Maybe point codex_path in your settings to its location."
+                )
 
         # Inject CLI config overrides so the spawned session matches
         # project/global settings. Proto subcommand only forwards `-c` overrides.


### PR DESCRIPTION
If the user provided a string handle it with `shlex.split`.  In case the first part of it, refer to it as executable, is not given as an absolute path, use `shutil.which` to resolve it.

This allows (1) short names like "codex" to be expanded to its full path, but also (2) complex commands like "sh --login -i -c codex" to get split and resolved automatically.  E.g. the latter could get transformed to `["C:\\Dev\\Git\\bin\\sh.exe", "--login", "-i", "codex"]`.